### PR TITLE
Follow pagination links from GitHub response headers

### DIFF
--- a/github_com.sh
+++ b/github_com.sh
@@ -11,9 +11,40 @@ user=$1
 token=$2
 org=$3
 
-reposJson=$(curl -f -s -u "$user:$token" $apiBase/orgs/$org/repos)
+reposJson=""
+URL="$apiBase/orgs/$org/repos?per_page=100"
+while [ "$URL" ]; do
+  echo "Info: checking URL:$URL"
+  RESP=$(curl -i -s -f -u "$user:$token" "$URL")
+  if [ $? -ne 0 ]; then
+    echo "######################"
+    echo "Error getting recursive repo information from GitHub with URL:$URL"
+    echo "running the command with verbose output enabled:"
+    echo "######################"
+    curl -i -v -u "$user:$token" "$URL"
+    exit 2
+  fi
+  HEADERS=$(echo "$RESP" | sed '/^\r$/q')
+  URL=$(echo "$HEADERS" | sed -n -E 's/link:.*<(.*?)>; rel="next".*/\1/p')
+  if [ $? -ne 0 ]; then
+    echo "######################"
+    echo "Error with extracting next page link from headers:$HEADERS"
+    echo "MacOS users need to switch to a standard sed implementation, e.g., gnu-sed"
+    echo "######################"
+    exit 3
+  fi
+  reposJson="$reposJson $(echo "$RESP" | sed '1,/^\r$/d')"
+done
 
 readarray -t repos < <(jq -c '.[] | {name: .name, full_name: .full_name, default_branch: .default_branch}' <<< $reposJson)
+if [ $? -ne 0 ]; then
+    echo "######################"
+    echo "readarray was added to bash in version 4"
+    echo "Make sure this script runs with such bash"
+    echo "MacOS users might need to update their bash, and the first line in this script to point at the updated bash"
+    echo "######################"
+    exit 4
+fi
 
 echo "Counting code from repos:"
 for repo in "${repos[@]}"; do
@@ -43,4 +74,3 @@ cloc --sum-reports --force-lang-def=sonar-lang-defs.txt --report-file=$org $file
 rm *.cloc
 
 exit 0;
-


### PR DESCRIPTION
I've also hardened a bit the implementation for Mac users (where default shell and sed commands are not standard).
Credits to @mheap for the [recursing loop ](https://michaelheap.com/follow-github-link-header-bash/) into the GitHup responses pages.