### PR TITLE
azure_devops_services: Allow for spaces & other characters

### DIFF
--- a/azure_devops_services.sh
+++ b/azure_devops_services.sh
@@ -10,6 +10,24 @@ apiBase=https://dev.azure.com/
 token=$1
 org=$2
 
+rawurlencode() {
+  local string="${1}"
+  local strlen=${#string}
+  local encoded=""
+  local pos c o
+
+  for (( pos=0 ; pos<strlen ; pos++ )); do
+     c=${string:$pos:1}
+     case "$c" in
+        [-_.~a-zA-Z0-9] ) o="${c}" ;;
+        * )               printf -v o '%%%02x' "'$c"
+     esac
+     encoded+="${o}"
+  done
+  echo "${encoded}"    # You can either set a return variable (FASTER) 
+  REPLY="${encoded}"   #+or echo the result (EASIER)... or both... :p
+}
+
 reposJson=$(curl -f -s -u ":$token" $apiBase$org/_apis/git/repositories?api-version=6.0)
 
 echo $reposJson
@@ -28,12 +46,14 @@ for repo in "${repos[@]}"; do
     remote_branch=$(jq -r '.default_branch' <<< $repo)
     branch=${remote_branch##*/}
     project=$(jq -r '.project' <<< $repo)
-    remoteUrl=https://$token@dev.azure.com/$org/$project/_git/$name
-    fileList+="$name.cloc "
+    encodedproject=$( rawurlencode "$project" )
+    encodedname=$( rawurlencode "$name" )
+    remoteUrl="https://$token@dev.azure.com/$org/$encodedproject/_git/$encodedname"
+    fileList+="$encodedname.cloc "
     echo Checking out $name - $branch
-    git clone $remoteUrl --depth 1 --branch $branch $name
+    git clone $remoteUrl --depth 1 --branch "$branch" "$name"
     echo Counting $name - $branch
-    cloc $name --force-lang-def=sonar-lang-defs.txt --report-file=$name.cloc  
+    cloc "$name" --force-lang-def=sonar-lang-defs.txt --report-file="$encodedname.cloc"
     rm -rf $name
 done
 


### PR DESCRIPTION
Adds quote marks and URL encoding so that azure_devops_services.sh doesn't puke on projects that have spaces in the name, or other characters other than letters and numbers.