### PR TITLE
Improve script stability for Orgs with many repositories

### DIFF
--- a/github_com.sh
+++ b/github_com.sh
@@ -70,7 +70,7 @@ done
 
 echo "Building final report:"
 
-cloc --sum-reports --force-lang-def=sonar-lang-defs.txt --report-file=$org $fileList
+cloc --sum-reports --force-lang-def=sonar-lang-defs.txt --report-file=$org *.cloc
 rm *.cloc
 
 exit 0;


### PR DESCRIPTION
Using $fileList can cause errors with too many repositories as the argument size is limited-