### PR TITLE
Update bitbucket_org.sh repo slug instead of name

### DIFF
--- a/bitbucket_org.sh
+++ b/bitbucket_org.sh
@@ -46,14 +46,14 @@ EXCLUDE=".clocignore"
 # Test if request for for 1 Repo or more Repo
 
 if [ -z ${4} ]; then 
-     jq_args=".values[] | \"\(.name):\(.uuid)\""
+     jq_args=".values[] | \"\(.slug):\(.uuid)\""
      # If you have more than 100 repos Change Value of parameter page=Number_of_page
      # 1 Page = 100 repos max
      # Example for 150 repos :
      #  GetAPI="orgs/$org/repos?pagelen=100&page=2"
      GetAPI="repositories/$wks?pagelen=100&page=1"
 else 
-    jq_args="\"\(.name):\(.uuid)\"" 
+    jq_args="\"\(.slug):\(.uuid)\"" 
     GetAPI="repositories/$wks/$4"
 fi
 


### PR DESCRIPTION
The value of "name" in the return json from the bitbucket api is like "My Name", but the value needed in the script later on is actually in "slug", which is like "my-name". Otherwise `$BaseAPI/repositories/$wks/$Name/refs/branches` produces a bad value and we get the error `jq: error (at <stdin>:0): Cannot iterate over null (null)`. 