### PR TITLE
fix: changed statement operator

### DIFF
--- a/PowerShell/filesystem.ps1
+++ b/PowerShell/filesystem.ps1
@@ -23,7 +23,7 @@ else {
       $directory=$args[0]
 
       if (Test-Path -Path $args[0]) {
-        if((Test-Path $CLOCPATH) || (Test-Path ($CLOCPATH+".exe"))) {
+        if((Test-Path $CLOCPATH) -Or (Test-Path ($CLOCPATH+".exe"))) {
             $repname=Split-Path -Path $args[0] -Leaf
              # Run Analyse : run cloc on the local repository
             $cmdparms2="--force-lang-def=sonar-lang-defs.txt --ignore-case-ext --report-file="+$repname +".cloc '" + $directory + "' --sum-one"


### PR DESCRIPTION
### Description

This PR fixes an issue in the PowerShell script `filesystem.ps1` where the script used a Bash-style logical OR operator (`||`) on line 26. PowerShell does not support `||` and throws a parse error when attempting to run the script.

### Fix

The expression:
```powershell
if((Test-Path $CLOCPATH) || (Test-Path ($CLOCPATH+".exe"))) {
```

was changed to:
```powershell
if((Test-Path $CLOCPATH) -Or (Test-Path ($CLOCPATH + ".exe"))) {
```

This change allows the script to run properly on Windows environments using PowerShell.