### PR TITLE
Fix: PowerShell logical OR operator

### DIFF
--- a/PowerShell/filesystem.ps1
+++ b/PowerShell/filesystem.ps1
@@ -23,7 +23,7 @@ else {
       $directory=$args[0]
 
       if (Test-Path -Path $args[0]) {
-        if((Test-Path $CLOCPATH) || (Test-Path ($CLOCPATH+".exe"))) {
+        if((Test-Path $CLOCPATH) -or (Test-Path ($CLOCPATH+".exe"))) {
             $repname=Split-Path -Path $args[0] -Leaf
              # Run Analyse : run cloc on the local repository
             $cmdparms2="--force-lang-def=sonar-lang-defs.txt --ignore-case-ext --report-file="+$repname +".cloc '" + $directory + "' --sum-one"


### PR DESCRIPTION
### Summary

Fixes #44 

This PR fixes a PowerShell syntax error in `PowerShell/filesystem.ps1`, where the logical OR operator was incorrectly written as `||`, which is invalid in PowerShell.

### Fix Details

- Replaced:
  ```powershell
  if ((Test-Path $CLOCPATH) || (Test-Path ($CLOCPATH + ".exe")))

- With:
  ```powershell
  if ((Test-Path $CLOCPATH) -or (Test-Path ($CLOCPATH + ".exe")))

This change resolves the following error:
The token '||' is not a valid statement separator

