### PR TITLE
BUILD-11433: Update CODEOWNERS for obsolete team deletion

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @sonarsource/solutions-engineering
+* @SonarSource/solutions-engineering-team


### PR DESCRIPTION
## Summary

Repoint CODEOWNERS on `sonar-loc-count` away from obsolete GitHub team slugs scheduled for deletion under BUILD-11433 / BUILD-10839.

**Best-guess successors** (BHR-aligned teams). Reply on the PR or #ask-github-teams-migration if the target squad is wrong — we can amend before the obsolete team is destroyed.

### Mapping
- `@SonarSource/solutions-engineering -> @SonarSource/solutions-engineering-team (1)`

## Test plan

- [ ] Confirm successor squad is the right CODEOWNER
- [ ] Merge before obsolete team delete (Wave B/C step 2)

## Tracking

BUILD-11433